### PR TITLE
GH-31: Link der Routen zu Google Maps

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -18,6 +18,8 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - url_launcher_ios (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -26,6 +28,7 @@ DEPENDENCIES:
   - home_widget (from `.symlinks/plugins/home_widget/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
   trunk:
@@ -44,6 +47,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
@@ -53,6 +58,7 @@ SPEC CHECKSUMS:
   home_widget: 0434835a4c9a75704264feff6be17ea40e0f0d57
   path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
   shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
+  url_launcher_ios: 6116280ddcfe98ab8820085d8d76ae7449447586
 
 PODFILE CHECKSUM: 819463e6a0290f5a72f145ba7cde16e8b6ef0796
 

--- a/lib/services/maps_app_service.dart
+++ b/lib/services/maps_app_service.dart
@@ -1,14 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:gethome/models/get_home_location.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:gethome/models/get_home_route.dart';
 
 /// Documentation: MapsAppService
 ///
 /// 1 Method for the Maps App Service:
 /// - openRouteInGoogleMaps(GetHomeLocation start, GetHomeLocation end, DateTime departureTime): Opens Google Maps Directions for the given Start/End location and the departure time.
 class MapsAppService{
+  /// Method that takes a GetHomeRoute and calls the openRouteInGoogleMaps Method that lauches Google
+  /// Maps with for the given parameters. If the start or end location are not present, it will not
+  /// launch Google Maps. If the departure time is not present, it will take the current time.
+  static void openRouteInGoogleMaps(GetHomeRoute route) {
+    if (route.startLocation != null && route.endLocation != null) {
+      openLocationDirectionsInGoogleMaps(route.startLocation!, route.endLocation!, route.departureTime ?? DateTime.now());
+    }
+  }
+
   /// Opens Google Maps Directions for the given Start/End location and the departure time.
-  static void openRouteInGoogleMaps(GetHomeLocation start, GetHomeLocation end, DateTime departureTime){
+  static void openLocationDirectionsInGoogleMaps(GetHomeLocation start, GetHomeLocation end, DateTime departureTime){
     // Create the Google Maps URL as a Uri object, see: https://developers.google.com/maps/documentation/urls/get-started
     Uri googleMapsUrl = Uri(
       scheme: 'https',

--- a/lib/views/next_routes.dart
+++ b/lib/views/next_routes.dart
@@ -9,7 +9,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:gethome/services/current_location_service.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:gethome/views/list_tile_of_route.dart';
-
+import 'package:gethome/services/maps_app_service.dart';
 import 'package:home_widget/home_widget.dart';
 
 class RoutesScreen extends StatefulWidget {
@@ -138,7 +138,10 @@ class RoutesScreenState extends State<RoutesScreen> {
               ? Center(
                   child: Text(_errorMessage),
                 )
-              : RouteListTile(route: _nextRoutes![0], size: Size.large)),
+              : GestureDetector(
+                onTap: () => MapsAppService.openRouteInGoogleMaps(_nextRoutes![0]),
+                child: RouteListTile(route: _nextRoutes![0], size: Size.large))
+              ),
           const Divider(),
 
           // displaying the second route (in the same way as the first route of the list)
@@ -146,7 +149,10 @@ class RoutesScreenState extends State<RoutesScreen> {
               ? Center(
                   child: Text(_errorMessage),
                 )
-              : RouteListTile(route: _nextRoutes![1], size: Size.large)),
+              : GestureDetector(
+                onTap: () => MapsAppService.openRouteInGoogleMaps(_nextRoutes![1]),
+                child: RouteListTile(route: _nextRoutes![1], size: Size.large))
+              ),
           const Divider(),
 
           // displaying the third route (in the same way as the first route of the list)
@@ -154,7 +160,10 @@ class RoutesScreenState extends State<RoutesScreen> {
               ? Center(
                   child: Text(_errorMessage),
                 )
-              : RouteListTile(route: _nextRoutes![2], size: Size.large)),
+              : GestureDetector(
+                onTap: () => MapsAppService.openRouteInGoogleMaps(_nextRoutes![2]),
+                child: RouteListTile(route: _nextRoutes![2], size: Size.large))
+              ),
           const Divider(),
 
           // the following commented code is only for testing. it shows a preview of the widget.


### PR DESCRIPTION
Habe eine neue Methode geschrieben, die nur eine Route nimmt und damit dann die Methode für den Google Maps call aufruft. Hoffe die Änderungen passen so Janick...
Bei Tipp auf eine Route im RoutesScreen wird jetzt Google Maps geöffnet (funktioniert). Es gibt in der Klasse noch dreimal das gleiche Codesegment, um den Link aufzurufen, soll ich das noch in ne extra Methode packen, ist vielleicht schöner?
Diesmal sind die Podfile Änderungen gewollt, die gehören zum url Launcher dazu.