### PR TITLE
GH-36: string overflow fix

### DIFF
--- a/lib/views/list_tile_of_route.dart
+++ b/lib/views/list_tile_of_route.dart
@@ -40,11 +40,12 @@ class RouteListTile extends StatelessWidget {
                 ),
                 child: Text(
                   route.firstLineName.toString(),
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: Colors.white,
                     fontWeight: FontWeight.bold,
-                    fontSize: 18,
+                    fontSize: (route.firstLineName??'').length >= 4 ? 14 : 18,
                   ),
+                  overflow: TextOverflow.ellipsis,
                 ),
               ),
             ],


### PR DESCRIPTION
![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-10 at 12 08 39](https://github.com/GetHomeTUM/GetHomeTUM/assets/161826320/b580503b-ff64-44e8-a89e-f0b943530c60)
![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-10 at 12 09 24](https://github.com/GetHomeTUM/GetHomeTUM/assets/161826320/4c496a5c-e109-4623-bd79-5e15afc9ffaf)

Overflows bei den Linien werden jetzt wie auf den Bildern angezeigt. 4 Buchstaben werden verkleinert angezeigt, bei mehr als 4 gibt es einen Overflow mit "...".